### PR TITLE
Add Multiprocessing capability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.1.0"
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 DLPack = "53c2dc0f-f7d5-43fd-8906-6c0220547083"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 NQCBase = "78c76ebc-5665-4934-b512-82d81b5cbfb7"
 NQCModels = "c814dc9f-a51f-4eaf-877f-82eda4edad48"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MACEModels"
 uuid = "29bafc4c-4f38-420f-a153-8a5a5e0bd5f6"
 authors = ["Alexander Spears <alexander.spears@warwick.ac.uk> and contributors"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
@@ -9,6 +9,7 @@ DLPack = "53c2dc0f-f7d5-43fd-8906-6c0220547083"
 NQCBase = "78c76ebc-5665-4934-b512-82d81b5cbfb7"
 NQCModels = "c814dc9f-a51f-4eaf-877f-82eda4edad48"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -558,6 +558,8 @@ function NQCModels.derivative!(model::MACEModel, atoms::Atoms, D::AbstractArray{
     end
 end
 
-export MACEModel, MACEPredictionCache
+include("MACEModelsMPI.jl")
+
+export MACEModel, MACEPredictionCache, Ensemble
 
 end

--- a/src/MACEModelsMPI.jl
+++ b/src/MACEModelsMPI.jl
@@ -171,7 +171,7 @@ function SciMLBase.solve_batch(prob, alg, ensemblealg::CustomSplitDistributed, I
 end
 
 function start(config::MultiProcessConfig)
-    channel_split = collect(Iterators.partition(config.runners, Int(ceil(length(config.runners) ÷ length(config.evaluators))))) # Split into roughly equal parts
+    channel_split = collect(Iterators.partition(collect(1:length(config.runners)), Int(ceil(length(config.runners) ÷ length(config.evaluators))))) # Split into roughly equal parts
     for (idx,pid) in enumerate(config.evaluators)
         remote_do(config.model_listener, pid, config.model_loader_function, config.input_channels[channel_split[idx]], config.output_channels[channel_split[idx]])
         @debug "Evaluator dispatched on process $pid, listening on channels $(channel_split[idx])"

--- a/src/MACEModelsMPI.jl
+++ b/src/MACEModelsMPI.jl
@@ -1,5 +1,6 @@
 module Ensemble
 
+using MACEModels
 using Distributed
 using NQCModels
 import SciMLBase

--- a/src/MACEModelsMPI.jl
+++ b/src/MACEModelsMPI.jl
@@ -8,7 +8,7 @@ import SciMLBase
 struct MultiProcessConfig
     runners::Vector{Int} # NQCDynamics workers
     evaluators::Vector{Int} # MACE inference worker
-    remote_model::Model # Model to be evaluated
+    remote_model::NQCMOdels.Model # Model to be evaluated
     model_listener::Function
     input_channels::Vector{RemoteChannel}
     output_channels::Vector{RemoteChannel}

--- a/src/MACEModelsMPI.jl
+++ b/src/MACEModelsMPI.jl
@@ -40,8 +40,7 @@ Configuration for distributed execution dynamics propagation and model evaluatio
 function MultiProcessConfig(runners, evaluators, model_load_function::Function, positions_prototype; model_listener::Function=batch_evaluation_loop)
     input_channels = [RemoteChannel(()->Channel{typeof(positions_prototype)}(1)) for _ in runners]
     output_channels = [RemoteChannel(()->Channel{EnergyForcesCache{eltype(positions_prototype), typeof(positions_prototype)}}(1)) for _ in runners]
-    model = remotecall_fetch(model_load_function, first(evaluators))
-    return MultiProcessConfig(runners, evaluators, model, model_listener, input_channels, output_channels)
+    return MultiProcessConfig(runners, evaluators, model_load_function, model_listener, input_channels, output_channels)
 end
 
 """

--- a/src/MACEModelsMPI.jl
+++ b/src/MACEModelsMPI.jl
@@ -1,0 +1,180 @@
+module Ensemble
+
+using Distributed
+using NQCModels
+import SciMLBase
+
+struct MultiProcessConfig
+    runners::Vector{Int} # NQCDynamics workers
+    evaluators::Vector{Int} # MACE inference worker
+    model_load_function::Function
+    model_listener::Function
+    input_channels::Vector{RemoteChannel}
+    output_channels::Vector{RemoteChannel}
+end
+
+"""
+Ensemble algorithm which enforces the split between dynamics and inference workers provided. 
+
+**Even when specifying this EnsembleAlgorithm, you still need to manually dispatch**
+
+"""
+struct CustomSplitDistributed<:SciMLBase.BasicEnsembleAlgorithm
+    config::MultiProcessConfig
+    pmap_args::Dict{Symbol, Any}
+end
+
+"""
+    MultiProcessConfig(runners, evaluators, model_load_function::Function, model_listener::Function, positions_prototype)
+
+Configuration for distributed execution dynamics propagation and model evaluation. 
+
+# Arguments
+- `runners::Vector{Int}`: Process IDs of the NQCDynamics workers.
+- `evaluators::Vector{Int}`: Process IDs of the model evaluators.
+- `model_load_function::Function`: Function `()->x<:Model` that can load the model to be evaluated on any process. (i.e. not specific to a process)
+- `model_listener::Function`: Function that listens for structures on the input channels and outputs the results on the output channels. Default is `batch_evaluation_loop`. `(model, input_channels, output_channels)->()`
+- `positions_prototype`: Sample atomic positions to determine system size. 
+"""
+function MultiProcessConfig(runners, evaluators, model_load_function::Function, model_listener::Function=batch_evaluation_loop, positions_prototype)
+    input_channels = [RemoteChannel(()->Channel{typeof(positions_prototype)}(1)) for _ in runners]
+    output_channels = [RemoteChannel(()->Channel{EnergyForcesCache{eltype(positions_prototype), typeof(positions_prototype)}}(1)) for _ in runners]
+    return MultiProcessConfig(runners, evaluators, model_load_function, model_listener, input_channels, output_channels)
+end
+
+"""
+Containers for energy and forces, to be used in the RemoteModel.
+"""
+struct EnergyForcesCache{T, M}
+    energy::T
+    forces::M
+end  
+
+
+mutable struct RemoteModel <: NQCModels.AdiabaticModels.AdiabaticModel
+    config::MultiProcessConfig # static
+    mace_cache::EnergyForcesCache # mutable
+    dofs::Int # static
+    mobile_atoms # static
+end
+
+
+function mace_batch_predict(model::MACEModel, structures)
+    @debug "Predicting batch of $(length(structures)) structures on process $(myid())"
+    MACEModels.predict!(model, model.atoms, structures, model.cell)
+    energies = MACEModels.get_energy_mean(model.last_eval_cache)
+    forces = MACEModels.get_forces_mean(model.last_eval_cache)
+    return (energies, forces)
+end
+
+"""
+    batch_evaluation_loop(model<:Model, user_model_function::Function, input_channels::Vector{RemoteChannel}, output_channels::Vector{RemoteChannel}; max_delay = 1000)
+
+**This doesn't know how to use your model most efficiently, it only handles I/O between processes!**
+
+To use this communication wrapper, you need to define a function that evaluates your model and returns a tuple of energies and forces, as shown in the example:
+
+```
+function user_model_function(model<:Model, structures::AbstractVector{AbstractMatrix{Number}})
+    MACEModels.predict!(model, model.atoms, structures, model.cell)
+    energies = MACEModels.get_energy_mean(model.last_eval_cache) # This is a Vector{Number} type
+    forces = MACEModels.get_forces_mean(model.last_eval_cache) # This is a Vector{Matrix{Number}} type
+    return (energies, forces)
+end
+```
+
+It polls the input channels for new structures, and when it finds them, it evaluates them using the user-defined model function. 
+The results are then put back into the correct output channels.
+
+# Arguments
+- `model::Model`: The model that will be used for evaluation.
+- `user_model_function::Function`: The user-defined function that will be used to evaluate the model.
+
+"""
+function batch_evaluation_loop(model<:Model, user_model_function::Function=mace_batch_predict, input_channels::Vector{RemoteChannel}, output_channels::Vector{RemoteChannel}; max_delay = 1000)
+    i = 1 # Start polling for input every 1ms, then increase delay for every unsuccessfull poll
+    while true
+        sleep(1e-3 * i)
+        # Check for ready input channels, add structures to array
+        to_process = findall(isready, input_channels)
+        if isempty(to_process) # Nothing to do, increase delay before asking again. 
+            i ≤ max_delay ? i += 1 : nothing
+        else # Predict for all ready channels
+            structures = [take!(channel) for channel in input_channels[to_process]]
+            energies, forces = user_model_function(model, structures)
+            number_type = eltype(eltype(input_channels[1])) # Ensure that the output type is the same as the input type. 
+            !isa(energies, Vector) ? energies = [energies] : nothing
+            energies = convert.(number_type, energies)
+            !isa(forces, Vector) ? forces = [forces] : nothing
+            forces = convert.(Matrix{number_type}, forces)
+            # Put new outputs into output channels
+            for (predictor_idx, channel_idx) in enumerate(to_process)
+                put!(
+                    output_channels[channel_idx], # Assign back to the channel that requested the prediction
+                    EnergyForcesCache(energies[predictor_idx], 
+                    forces[predictor_idx]
+                    )
+                )
+                i = 1 # Reset delay
+            end
+        end
+    end
+end
+
+
+"""
+    RemoteModel(config::MultiProcessConfig, structure_prototype)
+
+Creates a RemoteModel that can be used to evaluate structures on a remote process.
+
+**The remote model must already be loaded, since model DoFs and mobile atoms are cached process-locally.**
+"""
+function RemoteModel(config::MultiProcessConfig, structure_prototype)
+    RemoteModel(
+        config,
+        EnergyForcesCache(zero(eltype(structure_prototype)), zeros(eltype(structure_prototype), size(structure_prototype))),
+        remotecall_fetch(() -> NQCModels.ndofs(remote_mace_model), config.evaluators[1]),
+        remotecall_fetch(() -> NQCModels.mobileatoms(remote_mace_model, size(structure_prototype, 2)), config.evaluators[1])
+    )
+end
+
+NQCModels.dofs(model::RemoteModel) = 1:model.dofs
+NQCModels.ndofs(model::RemoteModel) = model.dofs
+
+function NQCModels.potential(model::RemoteModel, R::Matrix{Float64})
+    @debug "Evaluating potential on process $(myid())"
+    put!(model.config.input_channels[findfirst(model.config.runners .== myid())], R)
+    wait(model.config.output_channels[findfirst(model.config.runners .== myid())])
+    model.mace_cache = take!(model.config.output_channels[findfirst(model.config.runners .== myid())])
+    return model.mace_cache.energy
+end
+
+function NQCModels.derivative!(model::RemoteModel, D::Matrix{Float64}, R::Matrix{Float64})
+    @debug "Evaluating derivative on process $(myid())"
+    put!(model.config.input_channels[findfirst(model.config.runners .== myid())], R)
+    wait(model.config.output_channels[findfirst(model.config.runners .== myid())])
+    model.mace_cache = take!(model.config.output_channels[findfirst(model.config.runners .== myid())])
+    D .-= model.mace_cache.forces
+end
+
+function SciMLBase.solve_batch(prob, alg, ensemblealg::CustomSplitDistributed, II, pmap_batch_size;
+    kwargs...)
+    runner_pool = CachingPool(ensemblealg.config.runners)
+
+    batch_data = pmap(runner_pool, II, batch_size = pmap_batch_size, retry_delays=[1,1]) do i
+        SciMLBase.batch_func(i, prob, alg; kwargs...)
+    end
+
+    SciMLBase.tighten_container_eltype(batch_data)
+end
+
+function start(config::MultiProcessConfig)
+    for pid in config.evaluators
+        remote_do(config.model_listener, pid, config.model_load_function(), config.input_channels, config.output_channels)
+        @debug "Evaluator dispatched on process $pid"
+    end
+end
+
+export RemoteModel, MultiProcessConfig, CustomSplitDistributed, start
+
+end

--- a/src/MACEModelsMPI.jl
+++ b/src/MACEModelsMPI.jl
@@ -8,7 +8,7 @@ import SciMLBase
 struct MultiProcessConfig
     runners::Vector{Int} # NQCDynamics workers
     evaluators::Vector{Int} # MACE inference worker
-    remote_model::NQCMOdels.Model # Model to be evaluated
+    remote_model::NQCModels.Model # Model to be evaluated
     model_listener::Function
     input_channels::Vector{RemoteChannel}
     output_channels::Vector{RemoteChannel}

--- a/src/MACEModelsMPI.jl
+++ b/src/MACEModelsMPI.jl
@@ -60,7 +60,7 @@ mutable struct RemoteModel <: NQCModels.AdiabaticModels.AdiabaticModel
 end
 
 
-function mace_batch_predict(model::MACEModel, structures)
+function mace_batch_predict(model::MACEModels.MACEModel, structures)
     @debug "Predicting batch of $(length(structures)) structures on process $(myid())"
     MACEModels.predict!(model, model.atoms, structures, model.cell)
     energies = MACEModels.get_energy_mean(model.last_eval_cache)


### PR DESCRIPTION
Since each point in a trajectory requires a model evaluation / inference step on the previous point, we want fast evaluation of our MACE model to allow us to simulate more / longer trajectories. 

While MACE model inference is much faster on a GPU, copying the input structure and output tensors from CPU -> GPU -> CPU is somewhat inefficient and can introduce a bottleneck. 

This is something the developers of MACE also realise, hence why MACE allows for batch evaluation of structures, where model input data is prepared for multiple structures at once, then concatenated into a larger array. 
GPU memory can easily deal with large arrays and it appears that a single copy + sync operation of an array concatenated from multiple structures is significantly faster than N separate copy + synchronise operations. 

To eliminate some of the bottleneck associated with host-device copies, the batch processing capability of MACE can be used to accelerate MD trajectories in a multiprocess setting by passing all model evaluation / inference steps to a single instance of the MACE model, as shown below. 

![GPU batching example](https://github.com/user-attachments/assets/70159919-0d82-442a-9a63-290a6782ec51)

I've added an `Ensemble` module to MACEModels.jl which enables this kind of process distribution. Documentation will be in a separate tutorial on NQCRecipes. 

![Potential evaluator loop](https://github.com/user-attachments/assets/4d50f7a3-d9a7-45c1-870d-06bc29ea4403)

