### PR TITLE
Models always load all learned atom types regardless of input atoms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MACEModels"
 uuid = "29bafc4c-4f38-420f-a153-8a5a5e0bd5f6"
 authors = ["Alexander Spears <alexander.spears@warwick.ac.uk> and contributors"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -183,7 +183,8 @@ function MACEModel(
     cutoff_radius = convert(default_dtype, unique(cutoff_radii)[1])
 
     # Build z-table
-    z_table = mace_tools[].utils.AtomicNumberTable(sort(unique(atoms.numbers)))
+    # Hardcoding this to the model so we can handle input structures using a subset of all learned atom types.
+    z_table = mace_tools[].utils.AtomicNumberTable(Vector(from_dlpack(models[1].atomic_numbers)))
 
     # Freeze parameters
     for model in models

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -303,7 +303,6 @@ function predict!(
             config = mace_configuration_from_nqcd_configuration(atoms[i], cell[i], R[i]; dtype=mace_interface.default_dtype)
             dataset[i] = mace_data[].AtomicData.from_config(config, mace_interface.z_table, mace_interface.cutoff_radius)
             @debug "Encoding structure $(i)/$(length(R))\n"
-            @debug @showR[i] mace_configuration = config mace_AtomicData = dataset[i]
         end
         # Initialise DataLoader
         batch_size = mace_interface.batch_size === nothing ? length(dataset) : mace_interface.batch_size # Ensure there is a batch size

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -324,9 +324,9 @@ function predict!(
             evalcache_index = (batch_index - 1) * batch_size # Pointer to the start of the batch in the output arrays
             for (model_index, model) in enumerate(mace_interface.models)
                 # Place copy of batch on model device
-                clone = Py(batch.clone().to(mace_interface.device[model_index]).to_dict())
+                clone = batch.clone().to(mace_interface.device[model_index])
                 # Evaluate model
-                model_output = Py(model(clone, compute_stress=true))
+                model_output = Py(model(clone.to_dict(), compute_stress=true))
                 @show model_output
                 # Split according to batching
                 @debug "Model $(model_index) output:" output = model_output

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -237,10 +237,10 @@ function mace_configuration_from_nqcd_configuration(
         cell_array = zeros(dtype, size(R, 1), size(R, 1))
     elseif isa(cell, PeriodicCell)
         pbc = cell.periodicity
-        cell_array = Matrix{eltype(R)}(@. ustrip(auconvert(u"Å", cell.vectors')))
+        cell_array = Matrix{eltype(R)}(ustrip.(auconvert.(u"Å", cell.vectors))')
     end
 
-    ase_positions = @. ustrip(auconvert(u"Å", R'))
+    ase_positions = ustrip.(auconvert.(u"Å", R))'
 
     config = mace_data[].utils.Configuration(
         atomic_numbers=PyList(atoms.numbers), # needs to be a list
@@ -302,6 +302,7 @@ function predict!(
         for i in eachindex(R)
             config = mace_configuration_from_nqcd_configuration(atoms[i], cell[i], R[i]; dtype=mace_interface.default_dtype)
             dataset[i] = mace_data[].AtomicData.from_config(config, mace_interface.z_table, mace_interface.cutoff_radius)
+            @debug "Encoding structure $(i)/$(length(R))\n" structure_data = R[i] mace_configuration = config mace_AtomicData=dataset[i]
         end
         # Initialise DataLoader
         batch_size = mace_interface.batch_size === nothing ? length(dataset) : mace_interface.batch_size # Ensure there is a batch size
@@ -319,6 +320,7 @@ function predict!(
 
         # Iterate through dataloader and evaluate each model
         for (batch_index, batch) in enumerate(mace_DataLoader)
+            @debug "Evaluating DataLoader batch $(batch_index)" batch = batch
             evalcache_index = (batch_index - 1) * batch_size # Pointer to the start of the batch in the output arrays
             for (model_index, model) in enumerate(mace_interface.models)
                 # Place copy of batch on model device
@@ -326,6 +328,7 @@ function predict!(
                 # Evaluate model
                 model_output = model(clone.to_dict(), compute_stress=true)
                 # Split according to batching
+                @debug "Model $(model_index) output:" output = model_output
                 #! Check how well this performs and whether this actually saves memory
                 energies = Array(from_dlpack(model_output["energy"].detach()))
                 forces = Array(from_dlpack(model_output["forces"].detach()))
@@ -438,6 +441,9 @@ function get_forces_mean(mace_cache::MACEPredictionCache)
     mean_forces = Vector{Matrix{eltype(mace_cache.forces[1])}}(undef, length(mace_cache.forces))
     for index in eachindex(mace_cache.forces)
         mean_forces[index] = dropdims(mean(austrip.(mace_cache.forces[index] .* u"eV/Å"); dims=3); dims=3) # Force is given in eV/Å
+        if sum(abs.(mean_forces[index]))≥0.1
+            @debug "Large forces detected in structure $(index)." forces = mean_forces[index] input_structures = mace_cache.input_structures
+        end
     end
     if length(mean_forces) == 1
         return mean_forces[1]

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -302,8 +302,8 @@ function predict!(
         for i in eachindex(R)
             config = mace_configuration_from_nqcd_configuration(atoms[i], cell[i], R[i]; dtype=mace_interface.default_dtype)
             dataset[i] = mace_data[].AtomicData.from_config(config, mace_interface.z_table, mace_interface.cutoff_radius)
-            @debug "Encoding structure $(i)/$(length(R))\n" 
-            @debug @showR[i] mace_configuration = config mace_AtomicData=dataset[i]
+            @debug "Encoding structure $(i)/$(length(R))\n"
+            @debug @showR[i] mace_configuration = config mace_AtomicData = dataset[i]
         end
         # Initialise DataLoader
         batch_size = mace_interface.batch_size === nothing ? length(dataset) : mace_interface.batch_size # Ensure there is a batch size
@@ -333,7 +333,7 @@ function predict!(
                 #! Check how well this performs and whether this actually saves memory
                 energies = Array(from_dlpack(model_output["energy"].contiguous().detach()))
                 forces = Array(from_dlpack(model_output["forces"].contiguous().detach()))
-                splitting = Array(from_dlpack(clone.ptr.contiguous()) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
+                splitting = Array(from_dlpack(clone.ptr.contiguous())) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
                 for structure_index in 2:length(splitting)
                     mace_interface.last_eval_cache.energies[evalcache_index+structure_index-1][model_index] = energies[structure_index-1]
                     mace_interface.last_eval_cache.forces[evalcache_index+structure_index-1][:, :, model_index] .= forces[:, splitting[structure_index-1]:splitting[structure_index]-1] # last index -1 because Julia includes last index in a slice
@@ -442,7 +442,7 @@ function get_forces_mean(mace_cache::MACEPredictionCache)
     mean_forces = Vector{Matrix{eltype(mace_cache.forces[1])}}(undef, length(mace_cache.forces))
     for index in eachindex(mace_cache.forces)
         mean_forces[index] = dropdims(mean(austrip.(mace_cache.forces[index] .* u"eV/Å"); dims=3); dims=3) # Force is given in eV/Å
-        if sum(abs.(mean_forces[index]))≥0.1
+        if sum(abs.(mean_forces[index])) ≥ 0.1
             @debug "Large forces detected in structure $(index)." forces = mean_forces[index] input_structures = mace_cache.input_structures[index]
         end
     end

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -142,7 +142,7 @@ function MACEModel(
                 if pyconvert(Int, torch[].cuda.device_count()) < parse(Int, split(dev, ":")[2])
                     throw(ArgumentError("CUDA device index out of range."))
                 end
-                torch[].cuda.set_device(split(dev, ":")[2])
+                torch[].cuda.set_device(dev)
             end
         elseif dev == "mps"
             if pyconvert(Bool, torch[].backends.mps.is_built())

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -334,8 +334,8 @@ function predict!(
                 forces = Array(from_dlpack(model_output["forces"].contiguous().detach()))
                 splitting = Array(from_dlpack(clone.ptr.contiguous().detach())) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
                 for structure_index in 2:length(splitting)
-                    @debug "Writing indices" batch = batch_index cache_pointer = evalcache_index structure = structure_index calc_index = evalcache_index+structure_index-1
-                    @debug "Reading indices" lower_bound = splitting[structure_index-1] upper_bound = splitting[structure_index]-1]
+                    @debug "Writing indices\nBatch: $(batch_index)\nCache Pointer: $(evalcache_index)\nStructure index: $(structure_index)\nCalculated index: $(evalcache_index+structure_index-1)"
+                    @debug "Reading indices\nLower: $(splitting[structure_index-1])\nUpper: $(splitting[structure_index]-1)"
                     mace_interface.last_eval_cache.energies[evalcache_index+structure_index-1][model_index] = energies[structure_index-1]
                     mace_interface.last_eval_cache.forces[evalcache_index+structure_index-1][:, :, model_index] .= forces[:, splitting[structure_index-1]:splitting[structure_index]-1] # last index -1 because Julia includes last index in a slice
                 end

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -134,6 +134,7 @@ function MACEModel(
         if split(dev, ":")[1] == "cuda"
             if pyconvert(Bool, torch[].backends.cuda.is_built())
                 @debug "CUDA device available, using GPU."
+                torch[].cuda.init() # Maybe this will help weirdness for selecting second GPU
             else
                 @warn "CUDA device not available, falling back to CPU."
                 dev = "cpu"
@@ -334,8 +335,6 @@ function predict!(
                 forces = Array(from_dlpack(model_output["forces"].contiguous().detach()))
                 splitting = Array(from_dlpack(clone.ptr.contiguous().detach())) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
                 for structure_index in 2:length(splitting)
-                    @debug "Writing indices\nBatch: $(batch_index)\nCache Pointer: $(evalcache_index)\nStructure index: $(structure_index)\nCalculated index: $(evalcache_index+structure_index-1)"
-                    @debug "Reading indices\nLower: $(splitting[structure_index-1])\nUpper: $(splitting[structure_index]-1)"
                     mace_interface.last_eval_cache.energies[evalcache_index+structure_index-1][model_index] = energies[structure_index-1]
                     mace_interface.last_eval_cache.forces[evalcache_index+structure_index-1][:, :, model_index] .= forces[:, splitting[structure_index-1]:splitting[structure_index]-1] # last index -1 because Julia includes last index in a slice
                 end
@@ -438,6 +437,7 @@ end
 
 Returns the mean forces of the structures stored in the evaluation cache.
 Forces are returned in units of **Hartree/Bohr**.
+Warning: This function does not respect mobileatoms constraints. Forces for frozen atoms must be manually set to 0
 """
 function get_forces_mean(mace_cache::MACEPredictionCache)
     mean_forces = Vector{Matrix{eltype(mace_cache.forces[1])}}(undef, length(mace_cache.forces))
@@ -459,6 +459,7 @@ end
 
 Returns the force variance of the structures stored in the evaluation cache.
 Forces are returned in units of **Hartree²/Bohr²**.
+Warning: This function does not respect mobileatoms constraints. Forces for frozen atoms must be manually set to 0
 """
 function get_forces_variance(mace_cache::MACEPredictionCache)
     mean_forces = Vector{Matrix{eltype(mace_cache.forces[1])}}(undef, length(mace_cache.forces))
@@ -476,6 +477,8 @@ end
     get_forces_ensemble(mace_cache::MACEPredictionCache)
 
 Returns the forces evaluated by each model in the ensemble in units of **Hartree/Bohr**.
+
+Warning: This function does not respect mobileatoms constraints. Forces for frozen atoms must be manually set to 0
 """
 function get_forces_ensemble(mace_cache::MACEPredictionCache)
     ensemble_forces = Vector{typeof(mace_cache.forces[1])}(undef, length(mace_cache.forces))

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -302,7 +302,6 @@ function predict!(
         for i in eachindex(R)
             config = mace_configuration_from_nqcd_configuration(atoms[i], cell[i], R[i]; dtype=mace_interface.default_dtype)
             dataset[i] = mace_data[].AtomicData.from_config(config, mace_interface.z_table, mace_interface.cutoff_radius)
-            @debug "Encoding structure $(i)/$(length(R))\n"
         end
         # Initialise DataLoader
         batch_size = mace_interface.batch_size === nothing ? length(dataset) : mace_interface.batch_size # Ensure there is a batch size
@@ -320,16 +319,13 @@ function predict!(
 
         # Iterate through dataloader and evaluate each model
         for (batch_index, batch) in enumerate(mace_DataLoader)
-            @debug "Evaluating DataLoader batch $(batch_index)" batch = batch
             evalcache_index = (batch_index - 1) * batch_size # Pointer to the start of the batch in the output arrays
             for (model_index, model) in enumerate(mace_interface.models)
                 # Place copy of batch on model device
                 clone = batch.clone().to(mace_interface.device[model_index])
                 # Evaluate model
                 model_output = Py(model(clone.to_dict(), compute_stress=true))
-                @show model_output
                 # Split according to batching
-                @debug "Model $(model_index) output:" output = model_output
                 #! Check how well this performs and whether this actually saves memory
                 energies = Array(from_dlpack(model_output["energy"].contiguous().detach()))
                 forces = Array(from_dlpack(model_output["forces"].contiguous().detach()))

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -229,9 +229,12 @@ function mace_configuration_from_nqcd_configuration(
     R::AbstractMatrix;
     dtype::Type=Float64,
 )
+    #=
     if eltype(R) != dtype
         R = convert(Matrix{dtype}, R)
     end
+    =#
+    #! Removed positions type conversion to check if it affects prediction
     if isa(cell, InfiniteCell)
         pbc = zeros(Bool, size(R, 1))
         cell_array = zeros(dtype, size(R, 1), size(R, 1))
@@ -331,6 +334,8 @@ function predict!(
                 forces = Array(from_dlpack(model_output["forces"].contiguous().detach()))
                 splitting = Array(from_dlpack(clone.ptr.contiguous().detach())) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
                 for structure_index in 2:length(splitting)
+                    @debug "Writing indices" batch = batch_index cache_pointer = evalcache_index structure = structure_index calc_index = evalcache_index+structure_index-1
+                    @debug "Reading indices" lower_bound = splitting[structure_index-1] upper_bound = splitting[structure_index]-1]
                     mace_interface.last_eval_cache.energies[evalcache_index+structure_index-1][model_index] = energies[structure_index-1]
                     mace_interface.last_eval_cache.forces[evalcache_index+structure_index-1][:, :, model_index] .= forces[:, splitting[structure_index-1]:splitting[structure_index]-1] # last index -1 because Julia includes last index in a slice
                 end
@@ -504,7 +509,7 @@ function NQCModels.derivative(model::MACEModel, atoms::Atoms, R::AbstractMatrix,
     D = zeros(eltype(R), size(R))
     predict!(model, atoms, [R], cell)
     # Return derivative (mean is trivial)
-    @views D[:, model.mobile_atoms] .= -get_forces_mean(model.last_eval_cache)[:, model.mobile_atoms]
+    D[:, model.mobile_atoms] .-= @views get_forces_mean(model.last_eval_cache)[:, model.mobile_atoms]
     return D
 end
 
@@ -512,7 +517,7 @@ function NQCModels.derivative!(model::MACEModel, D::AbstractMatrix, atoms::Atoms
     # Evaluate model
     predict!(model, atoms, [R], cell)
     # Return derivative
-    @views D[:, model.mobile_atoms] .-= get_forces_mean(model.last_eval_cache)[:, model.mobile_atoms]
+    D[:, model.mobile_atoms] .-= @views get_forces_mean(model.last_eval_cache)[:, model.mobile_atoms]
 end
 
 # ToDo: Potential and derivative for multiple structures
@@ -542,7 +547,7 @@ function NQCModels.derivative(model::MACEModel, atoms::Atoms, R::Vector{<:Abstra
     # Return derivative (mean is trivial)
     D_full = get_forces_mean(model.last_eval_cache)
     for i in axes(D, 3)
-        @views D[i][:, model.mobile_atoms] .= -D_full[i][:, model.mobile_atoms]
+        D[i][:, model.mobile_atoms] .-= @views D_full[i][:, model.mobile_atoms]
     end
     return D
 end
@@ -558,7 +563,7 @@ function NQCModels.derivative!(model::MACEModel, atoms::Atoms, D::AbstractArray{
     predict!(model, atoms, R, cell)
     # Return derivative (mean is trivial)
     for i in axes(D, 3)
-        @views D[:, model.mobile_atoms, i] .-= get_forces_mean(model.last_eval_cache)[i][:, model.mobile_atoms]
+        D[:, model.mobile_atoms, i] .-= @views get_forces_mean(model.last_eval_cache)[i][:, model.mobile_atoms]
     end
 end
 

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -134,7 +134,6 @@ function MACEModel(
         if split(dev, ":")[1] == "cuda"
             if pyconvert(Bool, torch[].backends.cuda.is_built())
                 @debug "CUDA device available, using GPU."
-                torch[].cuda.init() # Maybe this will help weirdness for selecting second GPU
             else
                 @warn "CUDA device not available, falling back to CPU."
                 dev = "cpu"
@@ -143,6 +142,7 @@ function MACEModel(
                 if pyconvert(Int, torch[].cuda.device_count()) < parse(Int, split(dev, ":")[2])
                     throw(ArgumentError("CUDA device index out of range."))
                 end
+                torch[].cuda.set_device(split(dev, ":")[2])
             end
         elseif dev == "mps"
             if pyconvert(Bool, torch[].backends.mps.is_built())

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -166,7 +166,7 @@ function MACEModel(
             model = torch[].load(f=file_path, map_location=device[i])
             model = model.to(device[i])
             # Check if any rogue atoms contained in base structure
-            any(sort(unique(atoms.numbers)) ∉ Vector(from_dlpack(model.atomic_numbers))) || throw(ArgumentError("Example structure contains atom types not present in MACE model $(i)."))
+            any(sort(unique(atoms.numbers)) ∉ Vector(from_dlpack(model.atomic_numbers.contiguous()))) || throw(ArgumentError("Example structure contains atom types not present in MACE model $(i)."))
             # Model is safe to add to ensemble
             push!(models, model)
         catch e
@@ -184,7 +184,7 @@ function MACEModel(
 
     # Build z-table
     # Hardcoding this to the model so we can handle input structures using a subset of all learned atom types.
-    z_table = mace_tools[].utils.AtomicNumberTable(Vector(from_dlpack(models[1].atomic_numbers)))
+    z_table = mace_tools[].utils.AtomicNumberTable(Vector(from_dlpack(models[1].atomic_numbers.contiguous())))
 
     # Freeze parameters
     for model in models
@@ -302,7 +302,8 @@ function predict!(
         for i in eachindex(R)
             config = mace_configuration_from_nqcd_configuration(atoms[i], cell[i], R[i]; dtype=mace_interface.default_dtype)
             dataset[i] = mace_data[].AtomicData.from_config(config, mace_interface.z_table, mace_interface.cutoff_radius)
-            @debug "Encoding structure $(i)/$(length(R))\n" structure_data = R[i] mace_configuration = config mace_AtomicData=dataset[i]
+            @debug "Encoding structure $(i)/$(length(R))\n" 
+            @debug @showR[i] mace_configuration = config mace_AtomicData=dataset[i]
         end
         # Initialise DataLoader
         batch_size = mace_interface.batch_size === nothing ? length(dataset) : mace_interface.batch_size # Ensure there is a batch size
@@ -330,9 +331,9 @@ function predict!(
                 # Split according to batching
                 @debug "Model $(model_index) output:" output = model_output
                 #! Check how well this performs and whether this actually saves memory
-                energies = Array(from_dlpack(model_output["energy"].detach()))
-                forces = Array(from_dlpack(model_output["forces"].detach()))
-                splitting = Array(from_dlpack(clone.ptr)) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
+                energies = Array(from_dlpack(model_output["energy"].contiguous().detach()))
+                forces = Array(from_dlpack(model_output["forces"].contiguous().detach()))
+                splitting = Array(from_dlpack(clone.ptr.contiguous()) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
                 for structure_index in 2:length(splitting)
                     mace_interface.last_eval_cache.energies[evalcache_index+structure_index-1][model_index] = energies[structure_index-1]
                     mace_interface.last_eval_cache.forces[evalcache_index+structure_index-1][:, :, model_index] .= forces[:, splitting[structure_index-1]:splitting[structure_index]-1] # last index -1 because Julia includes last index in a slice
@@ -442,7 +443,7 @@ function get_forces_mean(mace_cache::MACEPredictionCache)
     for index in eachindex(mace_cache.forces)
         mean_forces[index] = dropdims(mean(austrip.(mace_cache.forces[index] .* u"eV/Å"); dims=3); dims=3) # Force is given in eV/Å
         if sum(abs.(mean_forces[index]))≥0.1
-            @debug "Large forces detected in structure $(index)." forces = mean_forces[index] input_structures = mace_cache.input_structures
+            @debug "Large forces detected in structure $(index)." forces = mean_forces[index] input_structures = mace_cache.input_structures[index]
         end
     end
     if length(mean_forces) == 1

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -139,10 +139,8 @@ function MACEModel(
                 dev = "cpu"
             end
             if length(split(dev, ":")) == 2
-                if pyconvert(Int, torch[].cuda.device_count()) < parse(Int, split(dev, ":")[2])
-                    throw(ArgumentError("CUDA device index out of range."))
-                end
-                torch[].cuda.set_device(dev)
+                @warn "Running on a selected GPU is currently unsupported. Falling back to cuda:0. See https://github.com/NQCD/MACEModels.jl/issues/13 for more information"
+                dev = "cuda:0"
             end
         elseif dev == "mps"
             if pyconvert(Bool, torch[].backends.mps.is_built())

--- a/src/MACEModels.jl
+++ b/src/MACEModels.jl
@@ -237,10 +237,10 @@ function mace_configuration_from_nqcd_configuration(
         cell_array = zeros(dtype, size(R, 1), size(R, 1))
     elseif isa(cell, PeriodicCell)
         pbc = cell.periodicity
-        cell_array = Matrix{eltype(R)}(ustrip.(auconvert.(u"Å", cell.vectors))')
+        cell_array = permutedims(Matrix{eltype(R)}(ustrip.(auconvert.(u"Å", cell.vectors))), (2, 1))
     end
 
-    ase_positions = ustrip.(auconvert.(u"Å", R))'
+    ase_positions = permutedims(ustrip.(auconvert.(u"Å", R)), (2, 1))
 
     config = mace_data[].utils.Configuration(
         atomic_numbers=PyList(atoms.numbers), # needs to be a list
@@ -324,15 +324,16 @@ function predict!(
             evalcache_index = (batch_index - 1) * batch_size # Pointer to the start of the batch in the output arrays
             for (model_index, model) in enumerate(mace_interface.models)
                 # Place copy of batch on model device
-                clone = batch.clone().to(mace_interface.device[model_index])
+                clone = Py(batch.clone().to(mace_interface.device[model_index]).to_dict())
                 # Evaluate model
-                model_output = model(clone.to_dict(), compute_stress=true)
+                model_output = Py(model(clone, compute_stress=true))
+                @show model_output
                 # Split according to batching
                 @debug "Model $(model_index) output:" output = model_output
                 #! Check how well this performs and whether this actually saves memory
                 energies = Array(from_dlpack(model_output["energy"].contiguous().detach()))
                 forces = Array(from_dlpack(model_output["forces"].contiguous().detach()))
-                splitting = Array(from_dlpack(clone.ptr.contiguous())) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
+                splitting = Array(from_dlpack(clone.ptr.contiguous().detach())) .+ 1 # Array of batch item bounds in output arrays, +1 due to Julia-Python conversion
                 for structure_index in 2:length(splitting)
                     mace_interface.last_eval_cache.energies[evalcache_index+structure_index-1][model_index] = energies[structure_index-1]
                     mace_interface.last_eval_cache.forces[evalcache_index+structure_index-1][:, :, model_index] .= forces[:, splitting[structure_index-1]:splitting[structure_index]-1] # last index -1 because Julia includes last index in a slice


### PR DESCRIPTION
Fixes #11 by checking one of the loaded models for which atom types were learned. 
This will still fail without clear traceback if one of multiple models has learned different atom types. 